### PR TITLE
Fix broken queued services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,8 @@ All notable changes to PerfectOblivion/Actions will be documented in this file
 ## 0.0.5 - 2019-12-28
 
 -   Service's ```$validator``` property should be "protected".
+
+## 0.0.6 - 2019-12-31
+
+-   Fix broken queued services.
+-   Remove ability to autorun queued services.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "perfect-oblivion/action-service-responder",
     "description": "Service aware actions for Laravel",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "keywords": [
         "perfect-oblivion",
         "actions",

--- a/src/Services/AbstractServiceCaller.php
+++ b/src/Services/AbstractServiceCaller.php
@@ -14,13 +14,6 @@ abstract class AbstractServiceCaller
     protected $container;
 
     /**
-     * The handler method to be called.
-     *
-     * @var string
-     */
-    public static $handlerMethod = 'run';
-
-    /**
      * Create a new service caller instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -34,41 +27,29 @@ abstract class AbstractServiceCaller
      * Call a service.
      *
      * @param  string  $service
-     * @param  mixed  $params
+     * @param  array  $params
+     * @param  array  $supplementals
      *
      * @return mixed
      */
-    abstract public function call($service, $params);
+    abstract public function call(string $service, array $params, array $supplementals = []);
 
     /**
      * Queue a service.
      *
      * @param  string  $service
-     * @param  mixed  $params
-     *
-     * @return mixed
+     * @param  array  $params
+     * @param  array  $supplementals
      */
-    abstract public function queue($service, $params);
+    abstract public function queue(string $service, array $params, array $supplementals = []): void;
 
     /**
      * Determine if the service handler method exists.
      *
      * @param  mixed  $service
-     *
-     * @return bool
      */
-    public function hasHandler($service)
+    public function hasHandler($service): bool
     {
-        return method_exists($service, $this::$handlerMethod);
-    }
-
-    /**
-     * Set the handler method name for services.
-     *
-     * @param  string  $method
-     */
-    public static function setHandlerMethod(string $method = 'run')
-    {
-        static::$handlerMethod = $method;
+        return method_exists($service, 'run');
     }
 }

--- a/src/Services/AbstractServiceCaller.php
+++ b/src/Services/AbstractServiceCaller.php
@@ -27,21 +27,21 @@ abstract class AbstractServiceCaller
      * Call a service.
      *
      * @param  string  $service
-     * @param  array  $params
+     * @param  array  $parameters
      * @param  array  $supplementals
      *
      * @return mixed
      */
-    abstract public function call(string $service, array $params, array $supplementals = []);
+    abstract public function call(string $service, array $parameters, array $supplementals = []);
 
     /**
      * Queue a service.
      *
      * @param  string  $service
-     * @param  array  $params
+     * @param  array  $parameters
      * @param  array  $supplementals
      */
-    abstract public function queue(string $service, array $params, array $supplementals = []): void;
+    abstract public function queue(string $service, array $parameters, array $supplementals = []): void;
 
     /**
      * Determine if the service handler method exists.

--- a/src/Services/Contracts/ShouldQueueService.php
+++ b/src/Services/Contracts/ShouldQueueService.php
@@ -4,10 +4,5 @@ namespace PerfectOblivion\ActionServiceResponder\Services\Contracts;
 
 interface ShouldQueueService
 {
-    /**
-     * Automatically queue the service
-     *
-     * @param  array  $parameters
-     */
-    public function autoQueue(array $parameters): void;
+
 }

--- a/src/Services/QueuedService.php
+++ b/src/Services/QueuedService.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
 use PerfectOblivion\ActionServiceResponder\Services\Service;
 
 class QueuedService implements ShouldQueue
@@ -16,58 +17,75 @@ class QueuedService implements ShouldQueue
     /** @var string */
     protected $serviceClass;
 
-    /** @var \PerfectOblivion\ActionServiceResponder\Services\Service */
-    protected $service;
-
     /** @var array */
     protected $parameters;
+
+    /** @var array */
+    protected $data;
+
+    /** @var bool */
+    protected $validated;
+
+    /** @var \Illuminate\Support\Collection */
+    protected $supplementals;
+
+    /** @var array */
+    protected $props;
 
     /**
      * Construct a new QueuedService.
      *
      * @param  \PerfectOblivion\ActionServiceResponder\Services\Service  $service
      * @param  array  $parameters
+     * @param  array  $data
+     * @param  bool  $validated
+     * @param  \Illuminate\Support\Collection  $supplementals
+     * @param  array  $props
      */
-    public function __construct(Service $service, array $parameters)
+    public function __construct(Service $service, array $parameters, array $data, bool $validated, Collection $supplementals, array $props)
     {
         $this->serviceClass = get_class($service);
-        $this->service = $service;
         $this->parameters = $parameters;
+        $this->data = $data;
+        $this->validated = $validated;
+        $this->supplementals = $supplementals;
+        $this->props = $props;
         $this->resolveQueueableProperties($service);
-    }
-
-    /**
-     * Get the display name for the class.
-     *
-     * @return string
-     */
-    public function displayName()
-    {
-        return $this->serviceClass;
     }
 
     /**
      * Handle the QueuedService.
      */
-    public function handle()
+    public function handle(): void
     {
-        $this->service->run($this->parameters);
+        $service = resolve($this->serviceClass);
+        $this->setRequiredServiceProperties($service);
+        $this->setPublicServiceProperties($service);
+        $service->run($this->parameters);
+    }
+
+    /**
+     * Get the display name for the class.
+     */
+    public function displayName(): string
+    {
+        return $this->serviceClass;
     }
 
     /**
      * The tags for identifying the queued service.
-     *
-     * @return array
      */
-    public function tags()
+    public function tags(): array
     {
         return ['queued_service'];
     }
 
     /**
      * Resolve the queable properties.
+     *
+     * @param  mixed  $service
      */
-    protected function resolveQueueableProperties()
+    protected function resolveQueueableProperties($service): void
     {
         $queueableProperties = [
             'connection',
@@ -79,7 +97,31 @@ class QueuedService implements ShouldQueue
         ];
 
         foreach ($queueableProperties as $queueableProperty) {
-            $this->{$queueableProperty} = $this->service->{$queueableProperty} ?? $this->{$queueableProperty};
+            $this->{$queueableProperty} = $service->{$queueableProperty} ?? $this->{$queueableProperty};
+        }
+    }
+
+    /**
+     * Set the required Service properties.
+     *
+     * @param  \PerfectOblivion\ActionServiceResponder\Services\Service  $service
+     */
+    private function setRequiredServiceProperties(Service $service): void
+    {
+        $service->setData($this->data);
+        $service->setIsValidated($this->validated);
+        $service->setSupplementals($this->supplementals);
+    }
+
+    /**
+     * Set the public properties for the Service
+     *
+     * @param  \PerfectOblivion\ActionServiceResponder\Services\Service  $service
+     */
+    private function setPublicServiceProperties(Service $service): void
+    {
+        foreach($this->props as $key => $value) {
+            $service->{$key} = $value;
         }
     }
 }

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -34,8 +34,8 @@ abstract class Service
         $validator = $this->getValidator();
 
         if ($validator) {
-            $this->setValidatedData($validator->validate($validator->data));
             $validator->service = $this;
+            $this->setValidatedData($validator->validate($validator->data));
         } else {
             $this->setData(resolve('request')->all());
         }

--- a/src/Services/ServiceCaller.php
+++ b/src/Services/ServiceCaller.php
@@ -3,13 +3,14 @@
 namespace PerfectOblivion\ActionServiceResponder\Services;
 
 use Illuminate\Contracts\Bus\Dispatcher;
-use Illuminate\Support\Collection;
 use PerfectOblivion\ActionServiceResponder\Services\Contracts\ShouldQueueService;
 use PerfectOblivion\ActionServiceResponder\Services\Exceptions\ServiceHandlerMethodException;
-use PerfectOblivion\ActionServiceResponder\Services\Service;
+use PerfectOblivion\ActionServiceResponder\Services\Traits\DisablesAutorun;
 
 class ServiceCaller extends AbstractServiceCaller
 {
+    use DisablesAutorun;
+
     /** @var \PerfectOblivion\ActionServiceResponder\Services\Service */
     protected $resolvedService;
 
@@ -17,105 +18,77 @@ class ServiceCaller extends AbstractServiceCaller
      * Call a service through its appropriate handler.
      *
      * @param  string  $service
-     * @param  array  $params
-     * @param  array  $supplementals
+     * @param  array  $parameters
+     * @param  array  $supplementalParameters
      *
      * @return mixed
      */
-    public function call(string $service, array $params, array $supplementals = [])
+    public function call(string $service, array $parameters, array $supplementalParameters = [])
     {
-        $this->prepareService($service, $supplementals);
-        $this->validateData($params);
+        $this->prepareService($service, $supplementalParameters);
+        $this->validateData($parameters);
 
-        return $this->shouldQueueService($this->resolvedService)
-            ? $this->dispatchService(
-                $params,
-                $this->resolvedService->getData(),
-                $this->resolvedService->isValidated(),
-                $this->resolvedService->getSupplementals(),
-                get_object_vars($this->resolvedService),
-            )
-            : $this->resolvedService->run($params);
+        return $this->shouldQueueService() ? $this->dispatchService($parameters) : $this->resolvedService->run($parameters);
     }
 
     /**
-     * Push the service call to the queue..
+     * Push the service call to the queue.
      *
      * @param  string  $service
-     * @param  array  $params
-     * @param  array  $supplementals
+     * @param  array  $parameters
+     * @param  array  $supplementalParameters
      *
      * @throws \PerfectOblivion\ActionServiceResponder\Exceptions\ServiceHandlerMethodException
      */
-    public function queue(string $service, array $params, array $supplementals = []): void
+    public function queue(string $service, array $parameters, array $supplementalParameters = []): void
     {
-        $this->prepareService($service, $supplementals);
-        $this->validateData($params);
-        $this->dispatchService(
-            $params,
-            $this->resolvedService->getData(),
-            $this->resolvedService->isValidated(),
-            $this->resolvedService->getSupplementals(),
-            get_object_vars($this->resolvedService),
-        );
+        $this->prepareService($service, $supplementalParameters);
+        $this->validateData($parameters);
+        $this->dispatchService($parameters);
     }
 
     /**
      * Prepare the Service to be run.
      *
      * @param  string  $service
-     * @param  array  $supplementals
+     * @param  array  $supplementalParameters
      */
-    private function prepareService(string $service, array $supplementals): void
+    private function prepareService(string $service, array $supplementalParameters): void
     {
         $this->confirmServiceHasHandler($service);
-        $this->temporarilyDisableAutorun();
+        $this->disableAutorun();
         $this->resolvedService = $this->container->make($service);
-        $this->resolvedService->buildSupplementals($supplementals);
+        $this->resolvedService->buildSupplementals($supplementalParameters);
     }
 
     /**
      * Call the service's validator if it exists and hasn't been called yet.
      *
-     * @param  array  $params
+     * @param  array  $parameters
      */
-    private function validateData(array $params = []): void
+    private function validateData(array $parameters = []): void
     {
         $validator = $this->resolvedService->getValidator();
 
         if ($validator) {
             $validator->service = $this->resolvedService;
             if (! $this->resolvedService->isValidated()) {
-                $this->resolvedService->setData($validator->validate($params));
+                $this->resolvedService->setData($validator->validate($parameters));
                 $this->resolvedService->setIsValidated(true);
             }
         } else {
-            $this->resolvedService->setData($params);
+            $this->resolvedService->setData($parameters);
         }
     }
 
     /**
      * Dispatch a fully initialized Service to the queue.
      *
-     * @param  array  $params
-     * @param  array  $data
-     * @param  bool  $validated
-     * @param  \Illuminate\Support\Collection  $supplementals
-     * @param  array  $props
+     * @param  array  $parameters
      */
-    private function dispatchService(array $params, array $data, bool $validated, Collection $supplementals, array $props): void
+    private function dispatchService(array $parameters): void
     {
-        resolve(Dispatcher::class)->dispatch(new QueuedService($this->resolvedService, $params, $data, $validated, $supplementals, $props));
-    }
-
-    /**
-     * Temporarily disable the service autorun.
-     */
-    private function temporarilyDisableAutorun(): void
-    {
-        $this->container->resolving(Service::class, function ($service, $app) {
-            $service->autorunIfEnabled = false;
-        });
+        resolve(Dispatcher::class)->dispatch(new QueuedService($this->resolvedService, $parameters));
     }
 
     /**
@@ -127,18 +100,14 @@ class ServiceCaller extends AbstractServiceCaller
      */
     private function confirmServiceHasHandler(string $service)
     {
-        if (! $this->hasHandler($service)) {
-            throw ServiceHandlerMethodException::notFound($service);
-        }
+        throw_unless($this->hasHandler($service), ServiceHandlerMethodException::notFound($service));
     }
 
     /**
      * Should the Service be queued?
-     *
-     * @param  \PerfectOblivion\ActionServiceResponder\Services\Service  $service
      */
-    private function shouldQueueService(Service $service): bool
+    private function shouldQueueService(): bool
     {
-        return $service instanceof ShouldQueueService;
+        return $this->resolvedService instanceof ShouldQueueService;
     }
 }

--- a/src/Services/Traits/CallsServices.php
+++ b/src/Services/Traits/CallsServices.php
@@ -11,27 +11,29 @@ trait CallsServices
      * Call a service.
      *
      * @param  string  $service
-     * @param  mixed  $params
+     * @param  array  $params
+     * @param  array  $supplementals
      *
      * @return mixed
      */
-    public function call(string $service, $params)
+    public function call(string $service, array $params, array $supplementals = [])
     {
-        return Container::getInstance()->make(ServiceCaller::class)->call($service, $params);
+        return Container::getInstance()->make(ServiceCaller::class)->call($service, $params, $supplementals);
     }
 
     /**
      * Push the service call to the queue..
      *
      * @param  string  $service
-     * @param  mixed  $params
+     * @param  array  $params
+     * @param  array  $supplementals
      *
      * @throws \PerfectOblivion\ActionServiceResponder\Exceptions\ServiceHandlerMethodException
      *
      * @return mixed
      */
-    public function queue(string $service, $params)
+    public function queue(string $service, array $params, array $supplementals = [])
     {
-        return Container::getInstance()->make(ServiceCaller::class)->queue($service, $params);
+        return Container::getInstance()->make(ServiceCaller::class)->queue($service, $params, $supplementals);
     }
 }

--- a/src/Services/Traits/CallsServices.php
+++ b/src/Services/Traits/CallsServices.php
@@ -11,29 +11,29 @@ trait CallsServices
      * Call a service.
      *
      * @param  string  $service
-     * @param  array  $params
+     * @param  array  $parameters
      * @param  array  $supplementals
      *
      * @return mixed
      */
-    public function call(string $service, array $params, array $supplementals = [])
+    public function call(string $service, array $parameters, array $supplementals = [])
     {
-        return Container::getInstance()->make(ServiceCaller::class)->call($service, $params, $supplementals);
+        return Container::getInstance()->make(ServiceCaller::class)->call($service, $parameters, $supplementals);
     }
 
     /**
      * Push the service call to the queue..
      *
      * @param  string  $service
-     * @param  array  $params
+     * @param  array  $parameters
      * @param  array  $supplementals
      *
      * @throws \PerfectOblivion\ActionServiceResponder\Exceptions\ServiceHandlerMethodException
      *
      * @return mixed
      */
-    public function queue(string $service, array $params, array $supplementals = [])
+    public function queue(string $service, array $parameters, array $supplementals = [])
     {
-        return Container::getInstance()->make(ServiceCaller::class)->queue($service, $params, $supplementals);
+        return Container::getInstance()->make(ServiceCaller::class)->queue($service, $parameters, $supplementals);
     }
 }

--- a/src/Services/Traits/DisablesAutorun.php
+++ b/src/Services/Traits/DisablesAutorun.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PerfectOblivion\ActionServiceResponder\Services\Traits;
+
+use Illuminate\Container\Container;
+use PerfectOblivion\ActionServiceResponder\Services\Service;
+
+trait DisablesAutorun
+{
+    /**
+     * Temporarily disable the service autorun.
+     */
+    private function disableAutorun(): void
+    {
+        Container::getInstance()->resolving(Service::class, function ($service, $app) {
+            $service->autorunIfEnabled = false;
+        });
+    }
+}

--- a/src/Services/Traits/SelfCallingService.php
+++ b/src/Services/Traits/SelfCallingService.php
@@ -11,23 +11,25 @@ trait SelfCallingService
      * Run the service.
      *
      * @param  array  $parameters
+     * @param  array  $supplementals
      *
      * @return mixed
      */
-    public static function call(array $parameters)
+    public static function call(array $parameters, array $supplementals = [])
     {
-        return Container::getInstance()->make(ServiceCaller::class)->call(static::class, $parameters);
+        return Container::getInstance()->make(ServiceCaller::class)->call(static::class, $parameters, $supplementals);
     }
 
     /**
      * Push the service call to the queue.
      *
      * @param  array  $parameters
+     * @param  array  $supplementals
      *
      * @return mixed
      */
-    public static function queue(array $parameters)
+    public static function queue(array $parameters, array $supplementals = [])
     {
-        return Container::getInstance()->make(ServiceCaller::class)->queue(static::class, $parameters);
+        return Container::getInstance()->make(ServiceCaller::class)->queue(static::class, $parameters, $supplementals);
     }
 }


### PR DESCRIPTION
Fix broken queued services
  - Do not assign service directly to property in QueuedService.
  - Do not allow queued services to be autorun.
  - Fix null service property on validator when using autorun.